### PR TITLE
Fix incorrect path to ReviveInjector

### DIFF
--- a/src/main/kotlin/com/cabbagedevelopment/condor2helper/MainApplication.kt
+++ b/src/main/kotlin/com/cabbagedevelopment/condor2helper/MainApplication.kt
@@ -39,7 +39,7 @@ fun main(args: Array<String>) {
  */
 class MainApplication : App(MainView::class) {
 
-    val injectorName = "ReviveInjector_x64.exe"
+    val injectorName = "ReviveInjector.exe"
     val prefs = Prefs()
     val view = find<MainView>()
 
@@ -86,7 +86,6 @@ class MainApplication : App(MainView::class) {
     fun save() {
         prefs.condorPath = view.condorText.text
         prefs.revivePath = view.reviveText.text
-        prefs.reviveInjectorPath = "${prefs.revivePath}\\$injectorName"
+        prefs.reviveInjectorPath = "${prefs.revivePath}\\x64\\$injectorName"
     }
 }
-


### PR DESCRIPTION
Fixes #1

In recent versions of Revive, `Revive/ReviveInjector_x64.exe` was moved to `Revive/x64/ReviveInjector.exe`. This the Revive Helper to attempt to launch a non-existent executable. The path has now been changed to the correct executable.